### PR TITLE
ci: add GitHub Actions workflow for CI/CD

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,29 @@
+version: 2
+updates:
+  # Enable version updates for Python dependencies
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "04:00"
+    open-pull-requests-limit: 5
+    assignees:
+      - "reh3376"
+    labels:
+      - "dependencies"
+      - "python"
+
+  # Enable version updates for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "04:00"
+    open-pull-requests-limit: 5
+    assignees:
+      - "reh3376"
+    labels:
+      - "dependencies"
+      - "github-actions"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,160 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+env:
+  UV_VERSION: 0.4.18
+  PYTHON_VERSION: "3.11"
+
+jobs:
+  test:
+    name: Test and Lint
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        python-version: ["3.11", "3.12"]
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v3
+      with:
+        version: ${{ env.UV_VERSION }}
+
+    - name: Create virtual environment
+      run: uv venv
+
+    - name: Install dependencies
+      run: |
+        uv pip install -e ".[dev]"
+
+    - name: Run ruff check
+      run: uv run ruff check
+
+    - name: Run ruff format check
+      run: uv run ruff format --check
+
+    - name: Run tests with coverage
+      run: |
+        uv run pytest --cov=src/email_assistant --cov-report=xml --cov-report=html --cov-report=term
+
+    - name: Upload coverage reports
+      uses: actions/upload-artifact@v4
+      if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11'
+      with:
+        name: coverage-report
+        path: |
+          coverage.xml
+          htmlcov/
+
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v4
+      if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11'
+      with:
+        file: ./coverage.xml
+        flags: unittests
+        name: codecov-umbrella
+        fail_ci_if_error: false
+        token: ${{ secrets.CODECOV_TOKEN }}
+
+  # Separate job for type checking
+  type-check:
+    name: Type Check
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ env.PYTHON_VERSION }}
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v3
+      with:
+        version: ${{ env.UV_VERSION }}
+
+    - name: Create virtual environment
+      run: uv venv
+
+    - name: Install dependencies
+      run: |
+        uv pip install -e ".[dev]"
+
+    - name: Run mypy
+      run: uv run mypy src/ --ignore-missing-imports
+
+  # Separate job for building
+  build:
+    name: Build Package
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ env.PYTHON_VERSION }}
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v3
+      with:
+        version: ${{ env.UV_VERSION }}
+
+    - name: Build package
+      run: |
+        uv build
+
+    - name: Upload build artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: dist-packages
+        path: dist/
+
+  # Comment on PR with test results
+  comment-results:
+    name: Comment Test Results
+    runs-on: ubuntu-latest
+    needs: [test, type-check]
+    if: github.event_name == 'pull_request'
+    permissions:
+      pull-requests: write
+    
+    steps:
+    - name: Comment PR
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const message = `## ✅ CI Results
+          
+          All checks have passed! 
+          
+          - 🧪 Tests: Passed
+          - 🎨 Formatting: Passed
+          - 🔍 Linting: Passed
+          - 📊 Coverage: Report uploaded
+          `;
+          
+          github.rest.issues.createComment({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: message
+          });

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Email Assistant (Desktop) — Local API + JSON Stores + Embedded Graph + Classifier
 
+[![CI](https://github.com/reh3376/email-agent/actions/workflows/ci.yml/badge.svg)](https://github.com/reh3376/email-agent/actions/workflows/ci.yml)
 [![Python 3.11+](https://img.shields.io/badge/python-3.11+-blue.svg)](https://www.python.org/downloads/)
 [![FastAPI](https://img.shields.io/badge/FastAPI-0.110+-green.svg)](https://fastapi.tiangolo.com)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -213,6 +213,31 @@ addopts = [
   "-v",
 ]
 
+[tool.coverage.run]
+source = ["src"]
+branch = true
+omit = [
+  "*/tests/*",
+  "*/__pycache__/*",
+  "*/migrations/*",
+  "*/.venv/*",
+  "*/venv/*",
+]
+
+[tool.coverage.report]
+exclude_lines = [
+  "pragma: no cover",
+  "def __repr__",
+  "raise AssertionError",
+  "raise NotImplementedError",
+  "if __name__ == .__main__.:",
+  "if TYPE_CHECKING:",
+  "@abstractmethod",
+]
+show_missing = true
+skip_covered = false
+precision = 2
+
 [tool.mypy]
 python_version = "3.11"
 packages = ["src/email_assistant"]


### PR DESCRIPTION
## Phase 1, Task 2: Add CI Workflow

This PR adds a comprehensive CI/CD workflow using GitHub Actions.

### Changes
- ✅ Add  with matrix testing
- ✅ Configure testing across Python 3.11 and 3.12
- ✅ Test on Ubuntu, Windows, and macOS
- ✅ Add linting with ruff
- ✅ Add formatting checks
- ✅ Add pytest with coverage reporting
- ✅ Add type checking with mypy
- ✅ Configure coverage uploads to artifacts and Codecov
- ✅ Add build verification
- ✅ Add PR comment automation
- ✅ Configure Dependabot for dependency updates
- ✅ Add CI status badge to README

### Test Steps
1. This PR will trigger the CI workflow
2. All checks should pass
3. Coverage artifacts will be uploaded
4. PR will receive automated comment with results

### Definition of Done
- [x] CI workflow runs on PRs and main branch
- [x] CI steps include: uv venv, install .[dev], ruff check, ruff format --check, pytest --cov
- [ ] PR triggers CI and passes
- [ ] Coverage artifact uploaded

Addresses Phase 1, Task 2 of the [phased implementation roadmap](docs/email-agent_phased_roadmap.md).